### PR TITLE
Addes alias for tailing log on the flux-helm-operator

### DIFF
--- a/bash_additions.sh
+++ b/bash_additions.sh
@@ -4,7 +4,7 @@ echo "Using bash_additions"
 
 #### ALIASES ####
 alias ll="ls -lhA"
-
+alias fluxlog="kubectl logs deployment/ssb-flux-helm-operator -f -n flux"
 
 #### FUNCTIONS ####
 


### PR DESCRIPTION
Added alias for retrieving log on the pod running the flux-helm-operator in whichever cluster your kubectl is "connected" to. Assuming that the depolyment is in the flux-namespace (which it, for now, always is).